### PR TITLE
merge tmp-docs into main

### DIFF
--- a/compiler-tests/simple/Cargo.lock
+++ b/compiler-tests/simple/Cargo.lock
@@ -50,6 +50,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +214,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +262,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +298,7 @@ version = "0.1.0"
 dependencies = [
  "macros",
  "runtime",
+ "sha2",
 ]
 
 [[package]]
@@ -591,10 +640,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "simple"
 version = "0.1.0"
 dependencies = [
  "compiler",
+ "rand",
+ "sha2",
 ]
 
 [[package]]
@@ -619,6 +681,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +698,12 @@ version = "0.1.0"
 dependencies = [
  "fnv",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/compiler-tests/simple/Cargo.toml
+++ b/compiler-tests/simple/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 compiler = {path = "./../../compiler", features=["verbose"]}
+sha2 = "0.10.8"
+rand = "0.8.0"
 
 [workspace]
 members = [ 

--- a/compiler-tests/simple/README.md
+++ b/compiler-tests/simple/README.md
@@ -1,0 +1,9 @@
+# Simple
+
+The risc-v program defined in `src/guest/main.rs` is harcoded with a secret `SALT`. It takes as input a random `message` and outputs `Sha256(message | SALT)`.
+
+## Run test
+
+```
+cargo run --release
+```

--- a/compiler-tests/simple/src/guest/Cargo.toml
+++ b/compiler-tests/simple/src/guest/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 runtime = { path = "../../../../runtime" }
 macros = { path = "../../../../macros" }
+sha2 = { version = "0.10.8", default-features = false}

--- a/compiler-tests/simple/src/main.rs
+++ b/compiler-tests/simple/src/main.rs
@@ -1,16 +1,24 @@
 use compiler::{interpreter::Phantom, CompileOpts};
 use core::ptr;
+use rand::{thread_rng, RngCore};
+use sha2::{Digest, Sha256};
 
 #[repr(C)]
 #[derive(Default)]
 struct Output {
-    value: u32,
+    hash_value: [u8; 32],
 }
 
 #[repr(C)]
 struct Input {
-    value: u32,
+    message: [u8; 32],
 }
+
+#[no_mangle]
+static SALT: [u8; 32] = [
+    175, 142, 86, 41, 61, 122, 186, 56, 50, 101, 187, 215, 124, 127, 14, 221, 109, 201, 110, 189,
+    174, 1, 87, 170, 113, 193, 170, 115, 85, 51, 79, 172,
+];
 
 fn to_u8_slice<T>(v: &T) -> &[u8] {
     unsafe { core::slice::from_raw_parts((v as *const T) as *const u8, core::mem::size_of::<T>()) }
@@ -21,29 +29,63 @@ fn from_u8_slice<T>(v: &[u8]) -> T {
 }
 
 fn main() {
+    // compile guest/main.rs to risc-v target
     let compiler = CompileOpts::new("guest");
     let elf_bytes = compiler.build();
-    // Initialise Phantom
+
+    // initialise phantom
+    //
+    // the `init` function transforms the risc-v binary
+    // into suitable format for execution on fhe-vm
     let pz = Phantom::init(elf_bytes);
 
-    let input = Input { value: 2 };
+    // prepare input
+    let mut input_message = [0u8; 32];
+    thread_rng().fill_bytes(&mut input_message);
+    let input = Input {
+        message: input_message,
+    };
+    // input is provided as buffer of bytes
+    let input_buffer = to_u8_slice(&input);
 
-    // Encrypted VM
-    let mut enc_vm = pz.encrypted_vm(to_u8_slice(&input), 200);
+    // encrypted vm runs for `max_cycles`
+    //
+    // this is necessary because vm cannot know when to halt
+    let max_cycles = 8725;
+
+    // create an encrypted vm instance
+    let mut enc_vm = pz.encrypted_vm(input_buffer, max_cycles);
+
+    // execute the vm
     enc_vm.execute();
 
-    // Test VM
+    // read output
+    let output_tape = enc_vm.output_tape();
+
+    // TEST VM //
     let mut test_vm = pz.test_vm();
     test_vm.read_input_tape(to_u8_slice(&input));
     let mut count = 0;
-    while test_vm.is_exec() && count < 200 {
+    while test_vm.is_exec() && count < max_cycles {
         test_vm.run();
         count += 1;
     }
 
-    // Check equivalance
-    let output_tape = enc_vm.output_tape();
+    // Check equivalance of encrypted vm output tape with test vm output tape
     let test_output_tape = test_vm.output_tape();
     assert_eq!(output_tape, test_output_tape);
-    // let output = from_u8_slice::<Output>(&output_tape);
+    // End TEST VM //
+
+    // Check output's correctness
+    let mut hasher = Sha256::new();
+    hasher.update(&input_message);
+    hasher.update(SALT);
+    let expected_hash = hasher.finalize().to_vec();
+    let output = from_u8_slice::<Output>(&test_output_tape);
+    assert!(
+        &output.hash_value == expected_hash.as_slice(),
+        "Expected {:?}, but got {:?}",
+        expected_hash.as_slice(),
+        &output.hash_value,
+    );
 }

--- a/compiler-tests/sybil-resistant-id/README.md
+++ b/compiler-tests/sybil-resistant-id/README.md
@@ -1,16 +1,16 @@
 # Anonymous sybil resistant identity system
 
-Assume a sybil-resistant identity system where an identity is represented as a tuple (`Signature`, `UniqueIdentifier`). Here, `UniqueIdentifier` is a unique, not necessarily hidden, identifier that distinguishes the identity holder, while `Signature` attests to its validity. An example of such a system is e-passports, where `UniqueIdentifier` consists of the holder’s personally identifiable data (e.g., Name, DOB, etc.), and `Signature` is a digital signature issued by the relevant authority.  
+Assume a sybil-resistant identity system where an identity is represented as a tuple (`Signature`, `UniqueIdentifier`). Here, `UniqueIdentifier` is a unique, not necessarily hidden, identifier that distinguishes the identity holder, while `Signature` attests to its validity. An example of such a system is e-passports, where `UniqueIdentifier` consists of the holder’s personally identifiable data (e.g., Name, DOB, etc.), and `Signature` is a digital signature issued by the relevant authority.
 
-This example demonstrates how to use `phantom` to bridge any sybil-resistant identity system to an anonymous identity. The encrypted RISC-V program embeds two secrets: `SECRET_KEY_PROGRAM` and `SALT`. Additionally, we assume that the public key `PUBLIC_KEY_PROGRAM` corresponding to `SECRET_KEY_PROGRAM` is publicly known, allowing verification of signatures produced with `SECRET_KEY_PROGRAM`.  
+This example demonstrates how to use `phantom` to bridge any sybil-resistant identity system to an anonymous identity. The encrypted RISC-V program embeds two secrets: `SECRET_KEY_PROGRAM` and `SALT`. Additionally, we assume that the public key `PUBLIC_KEY_PROGRAM` corresponding to `SECRET_KEY_PROGRAM` is publicly known, allowing verification of signatures produced with `SECRET_KEY_PROGRAM`.
 
-The program takes a sybil-resistant identity tuple (`Signature`, `UniqueIdentifier`) as input. It first verifies `Signature` using the fixed public key `PUBLIC_KEY_ISSUING_AUTH` of the issuing authority. If verification succeeds, it computes a new anonymous identifier as `Sha256(UniqueIdentifier || SALT)`. It then signs this anonymous identifier using `SECRET_KEY_PROGRAM` and outputs both the anonymous identifier and its corresponding signature.  
+The program takes a sybil-resistant identity tuple (`Signature`, `UniqueIdentifier`) as input. It first verifies `Signature` using the fixed public key `PUBLIC_KEY_ISSUING_AUTH` of the issuing authority. If verification succeeds, it computes a new anonymous identifier as `Sha256(UniqueIdentifier || SALT)`. It then signs this anonymous identifier using `SECRET_KEY_PROGRAM` and outputs both the anonymous identifier and its corresponding signature.
 
 Since the hardcoded secret `SALT` remains unknown, the resulting anonymous identifier is deterministic yet unlinkable to `UniqueIdentifier`.
 
 ## Structure
 
-The RISC-V program intended for encryption is defined in `src/guest/src/main.rs`, with its corresponding tests located in `main.rs`.  
+The RISC-V program intended for encryption is defined in `src/guest/src/main.rs`, with its corresponding tests located in `main.rs`.
 
 Every `phantom` program consists of two separate Cargo projects: `guest` and `main`. The `guest` project defines the actual encrypted program, while `main` handles compilation, encryption, and execution of `guest`. To compile successfully, `guest` must be included in `main`'s workspace (check [Cargo.toml](./Cargo.toml)).
 
@@ -20,7 +20,7 @@ The encrypted program is defined in the `main.rs` of the `guest` project and the
 
 ### Input and Output
 
-Refer to [main.rs](./src/guest/src/main.rs) in the `guest` project for an example of how inputs and outputs are managed.  
+Refer to [main.rs](./src/guest/src/main.rs) in the `guest` project for an example of how inputs and outputs are managed.
 
 Inputs are provided via memory, and outputs are retrieved from a predefined memory section. This approach reserves a dedicated memory space for inputs and outputs. It is implemented by declaring a sufficiently sized byte array as a static constant and linking these constants to the appropriate sections in the linker script.
 
@@ -35,11 +35,11 @@ static INPUT: [u8; core::mem::size_of::<Input>()] = [0u8; core::mem::size_of::<I
 static mut OUTPUT: [u8; core::mem::size_of::<Output>()] = [0u8; core::mem::size_of::<Output>()];
 ```
 
-The `INPUT` constant reserves space in memory for a byte array matching the size of the `Input` struct, placing it in the `.inpdata` section. Similarly, the `OUTPUT` constant reserves space for a byte array corresponding to the `Output` struct in the `.outdata` section.  
+The `INPUT` constant reserves space in memory for a byte array matching the size of the `Input` struct, placing it in the `.inpdata` section. Similarly, the `OUTPUT` constant reserves space for a byte array corresponding to the `Output` struct in the `.outdata` section.
 
 After compilation, `INPUT` and `OUTPUT` have dedicated memory allocations within the program. Before execution, inputs are mapped to their allocated memory, and after execution, outputs are retrieved from their respective memory locations.
 
-Inside the `main()` function, inputs are parsed into an `Input` struct using:  
+Inside the `main()` function, inputs are parsed into an `Input` struct using:
 
 ```rust
 let mut input: Input =
@@ -47,7 +47,7 @@ let mut input: Input =
 
 ```
 
-This requires all inputs to be defined within the `Input` struct. For example:  
+This requires all inputs to be defined within the `Input` struct. For example:
 
 ```rust
 #[repr(C)]
@@ -90,7 +90,7 @@ Note that both the `Input` and `Output` structs must include the `#[repr(C)]` at
 
 ### Selective reveal
 
-In [main.rs](./src/guest/src/main.rs) within the `guest` project, you'll notice that `SALT`, `SECRET_KEY_PROGRAM`, and `PUBLIC_KEY_ISSUING_AUTH` are defined as static constants. When the binary is encrypted, all three constants will be encrypted. However, only `SALT` and `SECRET_KEY_PROGRAM` need to remain secret, while `PUBLIC_KEY_ISSUING_AUTH` does not.  
+In [main.rs](./src/guest/src/main.rs) within the `guest` project, you'll notice that `SALT`, `SECRET_KEY_PROGRAM`, and `PUBLIC_KEY_ISSUING_AUTH` are defined as static constants. When the binary is encrypted, all three constants will be encrypted. However, only `SALT` and `SECRET_KEY_PROGRAM` need to remain secret, while `PUBLIC_KEY_ISSUING_AUTH` does not.
 
 In some cases, it may be necessary for parts of the program to remain in the clear. For example, in this case, `PUBLIC_KEY_ISSUING_AUTH` might need to be visible so it can be verified as the public key of a valid issuing authority. This concept is referred to as "selective reveal."
 
@@ -98,7 +98,19 @@ Selective revealing of program parts is not currently supported, but it will be 
 
 ## Run tests
 
-Run the tests with the following command at the root
+The program in `src/guest/main.rs` is big and requires approximately 25.9M cycles to finish. Thus, since a single encrypted vm cycle (recall, encrypted vm simulates risc-v vm using plaintext polynomial arithmetic) takes approximately 150ms, executing it on encrypted vm is not recommended. However if you still wish to run, then for the program to compile, modify `FLASH` size in `default.x` to at-least 128KB by changing the following line in `default.x`:
+
+```
+FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 32K
+```
+
+to
+
+```
+FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 128K
+```
+
+Then run the test with the following command at the root
 
 ```
 cargo run --release

--- a/compiler-tests/sybil-resistant-id/src/main.rs
+++ b/compiler-tests/sybil-resistant-id/src/main.rs
@@ -106,19 +106,23 @@ fn test_main_guest() {
     let pz = Phantom::init(elf_bytes);
 
     for _ in 0..1 {
-        let mut vm = pz.test_vm();
-
         let (is_sig_valid, random_input, output_hash) = gen_random_case();
 
+        let max_cycles = 25_900_000;
+
+        // Encrypted VM is too slow, at the moment, to run a program with 25.9M cycles in reasonable time
+        // let mut enc_vm = pz.encrypted_vm(to_u8_slice(&random_input), max_cycles);
+        // enc_vm.execute();
+
+        let mut vm = pz.test_vm();
         // Load inputs to the VM
         let input_tape = to_u8_slice(&random_input);
         vm.read_input_tape(input_tape);
         let mut count = 0usize;
-        while vm.is_exec() && count < 20_000_000 {
+        while vm.is_exec() && count < max_cycles {
             vm.run();
             count += 1;
         }
-        // println!("Total instructions: {}", count);
 
         // read outputs of the VM
         let output_tape = vm.output_tape();

--- a/compiler-tests/uniswap/Cargo.lock
+++ b/compiler-tests/uniswap/Cargo.lock
@@ -677,7 +677,6 @@ version = "0.1.0"
 dependencies = [
  "compiler",
  "rand 0.9.0",
- "rand_chacha 0.9.0",
 ]
 
 [[package]]

--- a/compiler-tests/uniswap/Cargo.toml
+++ b/compiler-tests/uniswap/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 compiler = {path = "./../../compiler", features = ["verbose"]}
 rand = "0.9.0"
-rand_chacha = "0.9.0"
 
 [workspace]
 members = [ 

--- a/compiler-tests/uniswap/src/main.rs
+++ b/compiler-tests/uniswap/src/main.rs
@@ -1,5 +1,5 @@
 use compiler::{CompileOpts, Phantom};
-use rand::{rng, Rng, SeedableRng};
+use rand::{rng, Rng};
 use std::ptr;
 
 fn to_u8_slice<T>(v: &T) -> &[u8] {
@@ -38,7 +38,7 @@ fn main() {
     let elf_bytes = compiler.build();
     let pz = Phantom::init(elf_bytes);
 
-    let mut rng = rand_chacha::ChaCha8Rng::from_seed(Default::default());
+    let mut rng = rng();
     let mut pool = Pool {
         t0: rng.random(),
         t1: rng.random(),
@@ -50,14 +50,14 @@ fn main() {
             inp1: rng.random(),
         };
 
-        let mut enc_vm = pz.encrypted_vm(to_u8_slice(&input), 60);
+        let mut enc_vm = pz.encrypted_vm(to_u8_slice(&input), 100);
         enc_vm.execute();
 
         // Init -> read input tape -> run -> read output tape
         let mut vm = pz.test_vm();
         vm.read_input_tape(to_u8_slice(&input));
         let mut count = 0;
-        while vm.is_exec() && count < 60 {
+        while vm.is_exec() && count < 100 {
             vm.run();
             count += 1;
         }

--- a/compiler/linker-script/default.x
+++ b/compiler/linker-script/default.x
@@ -3,8 +3,8 @@ ENTRY(_start)
 MEMORY
 {
     /* Define different memory regions for code and data memory */
-    FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 1K  /* Code memory */
-    RAM   (rwx) : ORIGIN = 0x3E800, LENGTH = 32K /* Data memory */
+    FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 20K  /* Code memory */
+    RAM   (rwx) : ORIGIN = 0x3E800, LENGTH = 16K /* Data memory */
 }
 
 SECTIONS

--- a/compiler/src/interpreter.rs
+++ b/compiler/src/interpreter.rs
@@ -14,6 +14,17 @@ mod testvm;
 
 const RAM_SIZE: usize = 1 << 14;
 
+mod macros {
+    macro_rules! verbose_println {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "verbose")]
+        println!($($arg)*);
+    };
+    }
+
+    pub(crate) use verbose_println;
+}
+
 struct BootMemory {
     data: Vec<u8>,
     offset: usize,
@@ -59,19 +70,11 @@ impl EncryptedVM {
     pub fn execute(&mut self) {
         let mut curr_cycles = 0;
         while curr_cycles < self.max_cycles {
+            // let time = std::time::Instant::now();
             self.interpreter.cycle(&self.params);
+            // println!("Time: {:?}", time.elapsed());
             curr_cycles += 1;
         }
-    }
-
-    pub fn print_debug(&self) {
-        println!(
-            "PC: {}",
-            self.interpreter
-                .addr_pc
-                .debug_as_u32(self.params.module_lwe())
-        );
-        println!("Registers: {:?}", self.interpreter.registers.debug_as_u32());
     }
 
     pub fn output_tape(&self) -> Vec<u8> {
@@ -117,7 +120,7 @@ impl Phantom {
                 .to_vec(),
         );
 
-        println!("ROM SIZE: {}", txthdr.p_memsz);
+        macros::verbose_println!("ROM SIZE: {} bytes", txthdr.p_memsz);
 
         // load all +r/+rw headers
         let hdrs: Vec<&ProgramHeader> = phdrs

--- a/compiler/src/interpreter/testvm.rs
+++ b/compiler/src/interpreter/testvm.rs
@@ -1,13 +1,6 @@
-use super::{BootMemory, InputInfo, OutputInfo};
+use super::{macros::verbose_println, BootMemory, InputInfo, OutputInfo};
 use std::fmt;
 use utils::{extract_bits, sign_extend};
-
-macro_rules! verbose_println {
-    ($($arg:tt)*) => {
-        #[cfg(feature = "verbose")]
-        println!($($arg)*);
-    };
-}
 
 struct Memory {
     data: Vec<u8>,
@@ -416,12 +409,11 @@ impl TestVM {
         }
 
         let inst_u32 = self.rom.read_word(self.pc as usize);
-        // println!("Inst raw = {:?} at pc={}", inst_u32, self.pc);
         let inst = self.decode_inst(inst_u32);
-        println!("XXXXXXXXXX");
-        println!("PC = {}", self.pc);
-        println!("REGs = {:?}", self.registers);
-        // println!("Inst = {:?} at pc={}", inst, self.pc);
+
+        verbose_println!("XXXXXXXXX");
+        verbose_println!("PC = {}", self.pc);
+        verbose_println!("REGs = {:?}", self.registers);
         match inst {
             Inst::ADDI(rs1, rd, imm) => {
                 verbose_println!(

--- a/fhevm/src/decompose.rs
+++ b/fhevm/src/decompose.rs
@@ -24,7 +24,7 @@ impl Base1D {
     pub fn decomp(&self, value: u32) -> Vec<u8> {
         let mut decomp: Vec<u8> = Vec::new();
         let mut sum_bases: u8 = 0;
-        self.0.iter().enumerate().for_each(|(i, base)| {
+        self.0.iter().enumerate().for_each(|(_i, base)| {
             decomp.push(((value >> sum_bases) & (1 << base) - 1) as u8);
             sum_bases += base;
         });


### PR DESCRIPTION
* set default FLASH size in default.x to 20KB
* update `compiler-tests/simple` example with hash function
* update sybil-resistant-id with 25.9M cycles for encrypted vm. Also, add directions in readme on updating FLASH size in `default.x` to 128KB which is necessary to compile